### PR TITLE
Added missing prereq Log::Log4perl as reported by CPANTS.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,6 +47,7 @@ my %module = (
         'Moo'                    => 2, # for some hashes-as-objects
         'WWW::Mechanize::Chrome' => '0.22',
         'Filter::signatures'     => '0.10',
+        'Log::Log4perl'          => 0,
 
     },
     TEST_REQUIRES => {


### PR DESCRIPTION
Hi @Corion 

Please review the PR.

Many Thanks.
Best Regards,
Mohammad S Anwar